### PR TITLE
Crop Growth Restrictions, v2

### DIFF
--- a/src/main/java/sereneseasons/config/FertilityConfig.java
+++ b/src/main/java/sereneseasons/config/FertilityConfig.java
@@ -7,9 +7,9 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import sereneseasons.core.SereneSeasons;
 
-@Config(modid = SereneSeasons.MOD_ID, name = SereneSeasons.MOD_ID+"/cropgrowth", category = "")
+@Config(modid = SereneSeasons.MOD_ID, name = SereneSeasons.MOD_ID+"/cropfertility", category = "")
 @Mod.EventBusSubscriber
-public class CropConfig {
+public class FertilityConfig {
 
 	public static General general_category = new General();
 	public static SeasonFertility seasonal_fertility = new SeasonFertility();
@@ -23,24 +23,29 @@ public class CropConfig {
 
 	public static class General{
 		@Config.Comment({"Whether crops break if out of season. If false, they simply don't grow"})
-		public boolean crops_break = true;
+		public boolean crops_break = false;
 		@Config.Comment({"Whether unlisted seeds are fertile every season. False means they're infertile every season"})
 		public boolean ignore_unlisted_crops = true;
 		@Config.Comment({"Whether to include tooltips on crops listing which seasons they're fertile in. " +
-				"Note: only applies to listed seeds"})
+				"Note: only applies to listed seeds. Currently not implemented."})
 		public boolean seed_tooltips = true;
+		@Config.Comment({"Whether to ignore tall grass growth. True means it will always grow"})
+		public boolean ignore_tall_grass = true;
+		@Config.Comment({"Whether to ignore sapling growth. True means it will always grow"})
+		public boolean ignore_saplings = true;
 	}
 
 	public static class SeasonFertility{
-		@Config.Comment({"Crops that do the opposite of what cropsBreak is set to"})
+		@Config.Comment({"Seeds that do the opposite of what cropsBreak is set to." +
+				"Seeds *only* listed here are considered \"unlisted\" for ignore_unlisted_crops"})
 		public String [] crops_break_opposite = new String[]{};
-		@Config.Comment({"Crops growable in the spring"})
-		public String [] spring_seeds = new String[]{"minecraft:potato"};
-		@Config.Comment({"Crops growable in the summer"})
-		public String [] summer_seeds = new String[]{"minecraft:potato", "minecraft:carrot"};
-		@Config.Comment({"Crops growable in the fall"})
+		@Config.Comment({"Seeds growable in the spring"})
+		public String [] spring_seeds = new String[]{"minecraft:potato", "minecraft:carrot"};
+		@Config.Comment({"Seeds growable in the summer"})
+		public String [] summer_seeds = new String[]{"minecraft:potato", "minecraft:carrot", "minecraft:wheat_seeds"};
+		@Config.Comment({"Seeds growable in the fall"})
 		public String [] fall_seeds = new String[]{"minecraft:potato", "minecraft:wheat_seeds"};
-		@Config.Comment({"Crops growable in the winter"})
+		@Config.Comment({"Seeds growable in the winter"})
 		public String [] winter_seeds = new String[]{"minecraft:potato"};
 	}
 }

--- a/src/main/java/sereneseasons/config/FertilityConfig.java
+++ b/src/main/java/sereneseasons/config/FertilityConfig.java
@@ -7,35 +7,43 @@ import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import sereneseasons.core.SereneSeasons;
 
+/**
+ * Configuration Handler for seasonal crop fertility
+ */
 @Config(modid = SereneSeasons.MOD_ID, name = SereneSeasons.MOD_ID+"/cropfertility", category = "")
 @Mod.EventBusSubscriber
-public class FertilityConfig {
+public class FertilityConfig
+{
 
 	public static General general_category = new General();
 	public static SeasonFertility seasonal_fertility = new SeasonFertility();
 
 	@SubscribeEvent
-	public static void onConfigChanged(ConfigChangedEvent.OnConfigChangedEvent event){
+	public static void onConfigChanged(ConfigChangedEvent.OnConfigChangedEvent event)
+	{
 		if(event.getModID().equals(SereneSeasons.MOD_ID)){
 			ConfigManager.sync(event.getModID(), Config.Type.INSTANCE); //resync config
 		}
 	}
 
-	public static class General{
+	public static class General
+	{
 		@Config.Comment({"Whether crops break if out of season. If false, they simply don't grow"})
 		public boolean crops_break = false;
-		@Config.Comment({"Whether unlisted seeds are fertile every season. False means they're infertile every season"})
+		@Config.Comment({"Whether unlisted seeds are fertile every season but winter. False means they're infertile every season," +
+				"and true means they're fertile every season except Winter"})
 		public boolean ignore_unlisted_crops = true;
 		@Config.Comment({"Whether to include tooltips on crops listing which seasons they're fertile in. " +
 				"Note: only applies to listed seeds. Currently not implemented."})
 		public boolean seed_tooltips = true;
-		@Config.Comment({"Whether to ignore tall grass growth. True means it will always grow"})
-		public boolean ignore_tall_grass = true;
 		@Config.Comment({"Whether to ignore sapling growth. True means it will always grow"})
-		public boolean ignore_saplings = true;
+		public boolean ignore_saplings = false;
+		@Config.Comment({"Maximum height greenhouse glass can be above a crop for it to be fertile out of season"})
+		public int greenhouse_glass_max_height = 7;
 	}
 
-	public static class SeasonFertility{
+	public static class SeasonFertility
+	{
 		@Config.Comment({"Seeds that do the opposite of what cropsBreak is set to." +
 				"Seeds *only* listed here are considered \"unlisted\" for ignore_unlisted_crops"})
 		public String [] crops_break_opposite = new String[]{};

--- a/src/main/java/sereneseasons/config/FertilityConfig.java
+++ b/src/main/java/sereneseasons/config/FertilityConfig.java
@@ -1,0 +1,46 @@
+package sereneseasons.config;
+
+import net.minecraftforge.common.config.Config;
+import net.minecraftforge.common.config.ConfigManager;
+import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import sereneseasons.core.SereneSeasons;
+
+@Config(modid = SereneSeasons.MOD_ID, name = SereneSeasons.MOD_ID+"/cropgrowth", category = "")
+@Mod.EventBusSubscriber
+public class CropConfig {
+
+	public static General general_category = new General();
+	public static SeasonFertility seasonal_fertility = new SeasonFertility();
+
+	@SubscribeEvent
+	public static void onConfigChanged(ConfigChangedEvent.OnConfigChangedEvent event){
+		if(event.getModID().equals(SereneSeasons.MOD_ID)){
+			ConfigManager.sync(event.getModID(), Config.Type.INSTANCE); //resync config
+		}
+	}
+
+	public static class General{
+		@Config.Comment({"Whether crops break if out of season. If false, they simply don't grow"})
+		public boolean crops_break = true;
+		@Config.Comment({"Whether unlisted seeds are fertile every season. False means they're infertile every season"})
+		public boolean ignore_unlisted_crops = true;
+		@Config.Comment({"Whether to include tooltips on crops listing which seasons they're fertile in. " +
+				"Note: only applies to listed seeds"})
+		public boolean seed_tooltips = true;
+	}
+
+	public static class SeasonFertility{
+		@Config.Comment({"Crops that do the opposite of what cropsBreak is set to"})
+		public String [] crops_break_opposite = new String[]{};
+		@Config.Comment({"Crops growable in the spring"})
+		public String [] spring_seeds = new String[]{"minecraft:potato"};
+		@Config.Comment({"Crops growable in the summer"})
+		public String [] summer_seeds = new String[]{"minecraft:potato", "minecraft:carrot"};
+		@Config.Comment({"Crops growable in the fall"})
+		public String [] fall_seeds = new String[]{"minecraft:potato", "minecraft:wheat_seeds"};
+		@Config.Comment({"Crops growable in the winter"})
+		public String [] winter_seeds = new String[]{"minecraft:potato"};
+	}
+}

--- a/src/main/java/sereneseasons/core/SereneSeasons.java
+++ b/src/main/java/sereneseasons/core/SereneSeasons.java
@@ -58,7 +58,7 @@ public class SereneSeasons
     @EventHandler
     public void postInit(FMLPostInitializationEvent event)
     {
-        ModFertility.setupTooltips();
+
     }
 
     @EventHandler

--- a/src/main/java/sereneseasons/core/SereneSeasons.java
+++ b/src/main/java/sereneseasons/core/SereneSeasons.java
@@ -2,6 +2,8 @@ package sereneseasons.core;
 
 import java.io.File;
 
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -15,10 +17,7 @@ import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLServerStartingEvent;
 import sereneseasons.command.SSCommand;
-import sereneseasons.init.ModBlocks;
-import sereneseasons.init.ModConfig;
-import sereneseasons.init.ModHandlers;
-import sereneseasons.init.ModItems;
+import sereneseasons.init.*;
 
 @Mod(modid = SereneSeasons.MOD_ID, version = SereneSeasons.MOD_VERSION, name = SereneSeasons.MOD_NAME, dependencies = "required-after:forge@[1.0.0.0,)")
 public class SereneSeasons
@@ -45,6 +44,7 @@ public class SereneSeasons
         ModBlocks.init();
         ModItems.init();
         ModHandlers.init();
+        ModFertility.init();
 
         proxy.registerRenderers();
     }
@@ -58,7 +58,7 @@ public class SereneSeasons
     @EventHandler
     public void postInit(FMLPostInitializationEvent event)
     {
-
+        ModFertility.setupTooltips();
     }
 
     @EventHandler

--- a/src/main/java/sereneseasons/handler/season/SeasonalCropGrowthHandler.java
+++ b/src/main/java/sereneseasons/handler/season/SeasonalCropGrowthHandler.java
@@ -1,20 +1,32 @@
 package sereneseasons.handler.season;
 
 import net.minecraft.block.*;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
 import net.minecraftforge.event.entity.player.BonemealEvent;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fml.common.eventhandler.Event;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import sereneseasons.api.SSBlocks;
 import sereneseasons.config.FertilityConfig;
 import sereneseasons.init.ModFertility;
 
-public class SeasonalCropGrowthHandler {
+public class SeasonalCropGrowthHandler
+{
 
 	@SubscribeEvent
-	public void onCropGrowth(BlockEvent.CropGrowEvent event){
+	public void onItemTooltipAdded(ItemTooltipEvent event)
+	{
+		ModFertility.setupTooltips(event);
+	}
+
+	@SubscribeEvent
+	public void onCropGrowth(BlockEvent.CropGrowEvent event)
+	{
 		Block plant = event.getState().getBlock();
 		boolean isFertile = ModFertility.isCropFertile(plant.getRegistryName().toString(), event.getWorld());
-		if(!isFertile && isFertilityApplicable(plant)){
+		if(isFertilityApplicable(plant) && !isFertile && !isGreenhouseGlassAboveBlock(event.getWorld(), event.getPos())){
 			if(ModFertility.shouldBreakCrop(plant.getRegistryName().toString()))
 				event.getWorld().destroyBlock(event.getPos(), true);
 			else
@@ -23,24 +35,36 @@ public class SeasonalCropGrowthHandler {
 	}
 
 	@SubscribeEvent
-	public void onBonemeal(BonemealEvent event){
+	public void onBonemeal(BonemealEvent event)
+	{
 		Block plant = event.getBlock().getBlock();
 		boolean isFertile = ModFertility.isCropFertile(plant.getRegistryName().toString(), event.getWorld());
-		if(!isFertile && isFertilityApplicable(plant)){
+		if(isFertilityApplicable(plant) && !isFertile && !isGreenhouseGlassAboveBlock(event.getWorld(), event.getPos()))
+		{
 			if(ModFertility.shouldBreakCrop(plant.getRegistryName().toString()))
 				event.getWorld().destroyBlock(event.getPos(), true);
 			event.setCanceled(true);
 		}
 	}
 
-	private boolean isFertilityApplicable(Block block){
+	private boolean isFertilityApplicable(Block block)
+	{
 		if(!(block instanceof IGrowable))
 			return false;
-		if(((block instanceof BlockTallGrass || block instanceof BlockDoublePlant || block instanceof BlockGrass)
-				&& FertilityConfig.general_category.ignore_tall_grass) ||
+		if(((block instanceof BlockTallGrass || block instanceof BlockDoublePlant || block instanceof BlockGrass)) ||
 				(block instanceof BlockSapling && FertilityConfig.general_category.ignore_saplings))
 			return false;
 		else
 			return true;
+	}
+
+	private boolean isGreenhouseGlassAboveBlock(World world, BlockPos cropPos)
+	{
+		for(int i = 0; i < FertilityConfig.general_category.greenhouse_glass_max_height; i++)
+		{
+			if(world.getBlockState(cropPos.add(0, i+1, 0)).getBlock().equals(SSBlocks.greenhouse_glass))
+				return true;
+		}
+		return false;
 	}
 }

--- a/src/main/java/sereneseasons/handler/season/SeasonalCropGrowthHandler.java
+++ b/src/main/java/sereneseasons/handler/season/SeasonalCropGrowthHandler.java
@@ -1,4 +1,46 @@
 package sereneseasons.handler.season;
 
+import net.minecraft.block.*;
+import net.minecraftforge.event.entity.player.BonemealEvent;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.common.eventhandler.Event;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import sereneseasons.config.FertilityConfig;
+import sereneseasons.init.ModFertility;
+
 public class SeasonalCropGrowthHandler {
+
+	@SubscribeEvent
+	public void onCropGrowth(BlockEvent.CropGrowEvent event){
+		Block plant = event.getState().getBlock();
+		boolean isFertile = ModFertility.isCropFertile(plant.getRegistryName().toString(), event.getWorld());
+		if(!isFertile && isFertilityApplicable(plant)){
+			if(ModFertility.shouldBreakCrop(plant.getRegistryName().toString()))
+				event.getWorld().destroyBlock(event.getPos(), true);
+			else
+				event.setResult(Event.Result.DENY);
+		}
+	}
+
+	@SubscribeEvent
+	public void onBonemeal(BonemealEvent event){
+		Block plant = event.getBlock().getBlock();
+		boolean isFertile = ModFertility.isCropFertile(plant.getRegistryName().toString(), event.getWorld());
+		if(!isFertile && isFertilityApplicable(plant)){
+			if(ModFertility.shouldBreakCrop(plant.getRegistryName().toString()))
+				event.getWorld().destroyBlock(event.getPos(), true);
+			event.setCanceled(true);
+		}
+	}
+
+	private boolean isFertilityApplicable(Block block){
+		if(!(block instanceof IGrowable))
+			return false;
+		if(((block instanceof BlockTallGrass || block instanceof BlockDoublePlant || block instanceof BlockGrass)
+				&& FertilityConfig.general_category.ignore_tall_grass) ||
+				(block instanceof BlockSapling && FertilityConfig.general_category.ignore_saplings))
+			return false;
+		else
+			return true;
+	}
 }

--- a/src/main/java/sereneseasons/handler/season/SeasonalCropGrowthHandler.java
+++ b/src/main/java/sereneseasons/handler/season/SeasonalCropGrowthHandler.java
@@ -1,0 +1,4 @@
+package sereneseasons.handler.season;
+
+public class SeasonalCropGrowthHandler {
+}

--- a/src/main/java/sereneseasons/init/ModFertility.java
+++ b/src/main/java/sereneseasons/init/ModFertility.java
@@ -1,0 +1,4 @@
+package sereneseasons.init;
+
+public class ModFertility {
+}

--- a/src/main/java/sereneseasons/init/ModFertility.java
+++ b/src/main/java/sereneseasons/init/ModFertility.java
@@ -1,4 +1,139 @@
 package sereneseasons.init;
 
+import net.minecraft.item.Item;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.text.TextFormatting;
+import net.minecraft.world.World;
+import net.minecraftforge.common.IPlantable;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+import scala.util.control.Exception;
+import sereneseasons.api.season.SeasonHelper;
+import sereneseasons.config.FertilityConfig;
+import sereneseasons.handler.season.SeasonHandler;
+
+import java.util.*;
+
+/**
+ * Constructs efficient data structures to process, store, and give access to data from the FertilityConfig file
+ */
 public class ModFertility {
+
+	private static HashSet<String> springPlants = new HashSet<String>();
+	private static HashSet<String> summerPlants = new HashSet<String>();
+	private static HashSet<String> fallPlants = new HashSet<String>();
+	private static HashSet<String> winterPlants = new HashSet<String>();
+	private static HashSet<String> allListedPlants = new HashSet<String>();
+	private static HashSet<String> oppositeBreak = new HashSet<String>();
+
+	//Maps seed name to all fertile seasons via byte
+	private static HashMap<String, Integer> seedSeasons= new HashMap<String, Integer>();
+
+	public static void init(){
+		//Store crops in hash sets for quick and easy retrieval
+		initSeasonCrops(FertilityConfig.seasonal_fertility.spring_seeds, springPlants, 1);
+		initSeasonCrops(FertilityConfig.seasonal_fertility.summer_seeds, summerPlants, 2);
+		initSeasonCrops(FertilityConfig.seasonal_fertility.fall_seeds, fallPlants, 4);
+		initSeasonCrops(FertilityConfig.seasonal_fertility.winter_seeds, winterPlants, 8);
+
+		initSeasonCrops(FertilityConfig.seasonal_fertility.crops_break_opposite, oppositeBreak, 0);
+	}
+
+	public static boolean isCropFertile(String cropName, World world){
+		//Get season
+		String sname = SeasonHelper.getSeasonState(world).getSeason().name();
+		//Check if crop's fertility is specified
+		if(sname.equals("SPRING") && springPlants.contains(cropName))
+			return true;
+		else if(sname.equals("SUMMER") && summerPlants.contains(cropName))
+			return true;
+		else if(sname.equals("AUTUMN") && fallPlants.contains(cropName))
+			return true;
+		else if(sname.equals("WINTER") && winterPlants.contains(cropName))
+			return true;
+
+		//Check if unspecified crops are by default fertile
+		if(!allListedPlants.contains(cropName) && FertilityConfig.general_category.ignore_unlisted_crops)
+			return true;
+
+		return false;
+	}
+
+	public static boolean shouldBreakCrop(String cropName){
+		boolean flag = false;
+		if(oppositeBreak.contains(cropName))
+			flag = true;
+		//Returns opposite of config if oppositeBreak is true
+		return flag ^ FertilityConfig.general_category.crops_break;
+	}
+
+	/**
+	 * Initializes the crops for a particular season. User's responsibility to match seeds and cropSet to be of the
+	 * same season (eg. String [] spring_seeds, HashSet springPlants)
+	 * @param seeds String array of seeds that are fertile during the chosen season
+	 * @param cropSet HashSet that will store the list of crops fertile during the chosen season
+	 */
+	private static void initSeasonCrops(String [] seeds, HashSet<String> cropSet, int bitmask){
+		for(String seed : seeds){
+			Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(seed));
+			if(item instanceof IPlantable){
+				String plantName = ((IPlantable) item).getPlant(null, null).getBlock().getRegistryName().toString();
+				cropSet.add(plantName);
+				if(bitmask != 0)
+					allListedPlants.add(plantName);
+				else
+					continue;
+
+				//Add to seedSeasons
+				if(seedSeasons.containsKey(seed)){
+					int seasons = seedSeasons.get(seed);
+					seedSeasons.put(seed, seasons | bitmask);
+				}else{
+					seedSeasons.put(seed, bitmask);
+				}
+			}
+		}
+	}
+
+	@SideOnly(Side.CLIENT)
+	public static void setupTooltips(){
+		//Set up tooltips if enabled and on client side
+		if(FertilityConfig.general_category.seed_tooltips) {
+			for (String seed : seedSeasons.keySet()) {
+				System.out.println("Adding tooltip to "+seed);
+				Item item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(seed));
+				item.addInformation(null, null, getFormattedSeasonNames(seedSeasons.get(seed)), null);
+			}
+		}
+	}
+
+	/**
+	 * Returns a list of formatted strings to add to a seed based on the parameter bitmask
+	 * @param mask Bitmask containing all selected seasons.
+	 * @return A list containing tooltips to add
+	 */
+	private static List<String> getFormattedSeasonNames(int mask){
+		LinkedList<String> toret = new LinkedList<String>();
+		String toadd = "";
+		if((mask & 1) != 0)
+			//toadd += TextFormatting.GREEN + "Sp";
+			toret.add(TextFormatting.GREEN + "Spring");
+		if((mask & 2) != 0)
+			//toadd += TextFormatting.YELLOW + "Su";
+			toret.add(TextFormatting.YELLOW + "Summer");
+		if((mask & 4) != 0)
+			//toadd += TextFormatting.GOLD + "Fa";
+			toret.add(TextFormatting.GOLD + "Fall");
+		if((mask & 8) != 0)
+			//toadd += TextFormatting.BLUE + "Wi";
+			toret.add(TextFormatting.BLUE + "Winter");
+
+		//toret.add(toadd);
+		for(String s : toret)
+			System.out.println(s);
+		return toret;
+	}
+
 }

--- a/src/main/java/sereneseasons/init/ModHandlers.java
+++ b/src/main/java/sereneseasons/init/ModHandlers.java
@@ -16,11 +16,7 @@ import sereneseasons.api.season.ISeasonColorProvider;
 import sereneseasons.api.season.SeasonHelper;
 import sereneseasons.config.BiomeConfig;
 import sereneseasons.handler.PacketHandler;
-import sereneseasons.handler.season.ProviderIceHandler;
-import sereneseasons.handler.season.RandomUpdateHandler;
-import sereneseasons.handler.season.SeasonHandler;
-import sereneseasons.handler.season.SeasonSleepHandler;
-import sereneseasons.handler.season.WeatherFrequencyHandler;
+import sereneseasons.handler.season.*;
 import sereneseasons.season.SeasonTime;
 import sereneseasons.util.SeasonColourUtil;
 
@@ -40,6 +36,7 @@ public class ModHandlers
         MinecraftForge.EVENT_BUS.register(new SeasonSleepHandler());
 
         MinecraftForge.EVENT_BUS.register(new WeatherFrequencyHandler());
+        MinecraftForge.EVENT_BUS.register(new SeasonalCropGrowthHandler());
 
         if (FMLCommonHandler.instance().getEffectiveSide() == Side.CLIENT)
         {


### PR DESCRIPTION
I made all of the changes specified, including changing the formatting and the default options for configurations. Other configurations were removed (tall grass), and greenhouse glass now allows crops below it to grow in any season. I assumed greenhouse glass works as a means of insulation, so if there is greenhouse glass within a configurable height above the plant, then it will be fertile, even if there are things in the way, or the glass has other opaque blocks above it. I also implemented tooltips for listed crops that show which seasons they're fertile in.