### PR TITLE
RandomUpdateHandler: Don't call BlockPos.down() that often.

### DIFF
--- a/src/main/java/sereneseasons/handler/season/RandomUpdateHandler.java
+++ b/src/main/java/sereneseasons/handler/season/RandomUpdateHandler.java
@@ -113,29 +113,22 @@ public class RandomUpdateHandler
 	                        {
 	                        	Block block = chunk.getBlockState(pos.getX(), y, pos.getZ()).getBlock();
 	                        	
-	                        	if (BiomeConfig.enablesSeasonalEffects(biome))
-	                        	{
-		                       		if (block == Blocks.SNOW_LAYER && SeasonASMHelper.getFloatTemperature(biome, pos) >= 0.15F)
+	                        	if (block == Blocks.SNOW_LAYER && SeasonASMHelper.getFloatTemperature(biome, pos) >= 0.15F)
+		                       	{
+		                       		world.setBlockToAir(pos);
+		                       		break;
+		                       	}
+		
+		                       	if(!first)
+		                       	{
+		                       		if(block == Blocks.ICE && SeasonASMHelper.getFloatTemperature(biome, pos) >= 0.15F)
 		                       		{
-		                       			world.setBlockToAir(pos);
+		                       			((BlockIce)Blocks.ICE).turnIntoWater(world, pos);
 		                       			break;
 		                       		}
-		
-		                       		if(!first)
-		                       		{
-		                       			if(block == Blocks.ICE && SeasonASMHelper.getFloatTemperature(biome, pos) >= 0.15F)
-		                       			{
-		                       				((BlockIce)Blocks.ICE).turnIntoWater(world, pos);
-		                       				break;
-		                       			}
-		                            }
-		                       		else
-		                       			first = false;
-	                        	}
-	                        	else
-	                        	{
-	                        		break;
-	                        	}
+		                        }
+		                       	else
+		                       		first = false;
 	                        }
 	                    }
 	                }

--- a/src/main/java/sereneseasons/handler/season/RandomUpdateHandler.java
+++ b/src/main/java/sereneseasons/handler/season/RandomUpdateHandler.java
@@ -103,12 +103,15 @@ public class RandomUpdateHandler
 	                        world.updateLCG = world.updateLCG * 3 + 1013904223;
 	                        int randOffset = world.updateLCG >> 2;
 	                        BlockPos pos = world.getPrecipitationHeight(new BlockPos(x + (randOffset & 15), 0, z + (randOffset >> 8 & 15)));
-	                        boolean first = true;
+	                        Biome biome = world.getBiome(pos);
 	
-	                        while (pos.getY() >= 0)
+	                        if(!BiomeConfig.enablesSeasonalEffects(biome))
+	                        	continue;
+	
+	                        boolean first = true;
+	                        for (int y = pos.getY(); y >= 0; y--)
 	                        {
-	                        	Block block = world.getBlockState(pos).getBlock();
-	                        	Biome biome = world.getBiome(pos);
+	                        	Block block = chunk.getBlockState(pos.getX(), y, pos.getZ()).getBlock();
 	                        	
 	                        	if (BiomeConfig.enablesSeasonalEffects(biome))
 	                        	{
@@ -128,8 +131,6 @@ public class RandomUpdateHandler
 		                            }
 		                       		else
 		                       			first = false;
-		
-		                       		pos = pos.down();
 	                        	}
 	                        	else
 	                        	{


### PR DESCRIPTION
As told in an earlier pull request the BlockPos.down() calls are pretty expensive in this hot loop. This is because internally they call new BlockPos(). To work around that we get the IBlockState from the chunk instead of the world. This way we're able to feed the getBlockState() call with Integer coordinates instead of BlockPos objects (that's what the world.getBlockState() call does internally, too).

Review and testing is highly appreciated.