### PR TITLE
Fix for changeWeatherFrequency

### DIFF
--- a/src/main/java/sereneseasons/init/ModHandlers.java
+++ b/src/main/java/sereneseasons/init/ModHandlers.java
@@ -37,10 +37,7 @@ public class ModHandlers
         MinecraftForge.TERRAIN_GEN_BUS.register(SEASON_HANDLER);
         SeasonHelper.dataProvider = SEASON_HANDLER;
         
-        if (ModConfig.seasons.generateSnowAndIce)
-        {
-        	MinecraftForge.EVENT_BUS.register(new RandomUpdateHandler());
-        }
+        MinecraftForge.EVENT_BUS.register(new RandomUpdateHandler());
         
         MinecraftForge.EVENT_BUS.register(new SeasonSleepHandler());
         


### PR DESCRIPTION
Disabling 'generateSnowAndIce' prevent the registration of
'RandomUpdateHandler', which prevent 'changeWeatherFrequency' to work.
('generateSnowAndIce' is corretly handled in 'RandomUpdateHandler' as
well as 'changeWeatherFrequency')