### PR TITLE
Drastically reduced overhead during chunk meshing

### DIFF
--- a/src/main/java/sereneseasons/api/season/Season.java
+++ b/src/main/java/sereneseasons/api/season/Season.java
@@ -25,7 +25,9 @@ public enum Season
         EARLY_WINTER(WINTER, 0xAF4F4F, 0.60F, 0xDB3030, 0.60F, 0xB1723B),
         MID_WINTER(WINTER, 0xAF4F4F, 0.45F, 0xDB3030, 0.45F, 0xA0824D),
         LATE_WINTER(WINTER, 0x8E8181, 0.60F, 0xA57070, 0.60F, 0x8F925F);
-        
+
+        public static final SubSeason[] VALUES = SubSeason.values();
+
         private Season season;
         private int grassOverlay;
         private float grassSaturationMultiplier;
@@ -87,6 +89,8 @@ public enum Season
         EARLY_WET(0x758C8A, 0x728C91, 0x80A755),
         MID_WET(0x548384, 0x2498AE, 0x76AC6C),
         LATE_WET(0x658989, 0x4E8893, 0x80A755);
+
+        public static final TropicalSeason[] VALUES = TropicalSeason.values();
 
         private int grassOverlay;
         private float grassSaturationMultiplier;

--- a/src/main/java/sereneseasons/command/SSCommand.java
+++ b/src/main/java/sereneseasons/command/SSCommand.java
@@ -62,7 +62,7 @@ public class SSCommand extends CommandBase
         EntityPlayerMP player = getCommandSenderAsPlayer(sender);
         Season.SubSeason newSeason = null;
 
-        for (Season.SubSeason season : Season.SubSeason.values())
+        for (Season.SubSeason season : Season.SubSeason.VALUES)
         {
             if (season.toString().toLowerCase().equals(args[1].toLowerCase()))
             {

--- a/src/main/java/sereneseasons/season/SeasonTime.java
+++ b/src/main/java/sereneseasons/season/SeasonTime.java
@@ -45,7 +45,7 @@ public final class SeasonTime implements ISeasonState
     @Override
     public int getCycleDuration()
     {
-        return getSubSeasonDuration() * Season.SubSeason.values().length;
+        return getSubSeasonDuration() * Season.SubSeason.VALUES.length;
     }
     
     @Override
@@ -63,8 +63,8 @@ public final class SeasonTime implements ISeasonState
     @Override
     public Season.SubSeason getSubSeason()
     {
-        int index = (this.time / getSubSeasonDuration()) % Season.SubSeason.values().length;
-        return Season.SubSeason.values()[index];
+        int index = (this.time / getSubSeasonDuration()) % Season.SubSeason.VALUES.length;
+        return Season.SubSeason.VALUES[index];
     }
 
     @Override
@@ -76,7 +76,7 @@ public final class SeasonTime implements ISeasonState
     @Override
     public Season.TropicalSeason getTropicalSeason()
     {
-        int index = ((((this.time / getSubSeasonDuration()) + 11) / 2) + 5) % Season.TropicalSeason.values().length;
-        return Season.TropicalSeason.values()[index];
+        int index = ((((this.time / getSubSeasonDuration()) + 11) / 2) + 5) % Season.TropicalSeason.VALUES.length;
+        return Season.TropicalSeason.VALUES[index];
     }
 }


### PR DESCRIPTION
This is an updated version of #58.

> While profiling the game with Serene Seasons and BetterFoliage installed, I discovered that `SeasonColourUtil#applySeasonalGrassColouring` was accounting for over 30% of the CPU time spent during chunk re-meshing. This was leading to small microstutters when placing blocks and sluggish chunk render generation.
>
> These changes are minimal and remove all unnecessary object cloning that was occuring by calling `SubSeason#values()` and `TropicalSeason#values()` in the hot code path. Additionally, I've changed the implmentation for `BiomeConfig` to use a HashMap with ResourceLocation keys instead of a LinkedMap with String keys to again significantly reduce overhead, as String creation and LinkedMap lookups are huge sore spots for performance in Java.
>
> After these changes, the impact of `SeasonColourUtil#applySeasonGrassColouring` is essentially nothing in the hot render loop and the in-game slowness is resolved.
