### PR TITLE
Adding dimension season-locking

### DIFF
--- a/src/main/java/sereneseasons/config/SeasonsConfig.java
+++ b/src/main/java/sereneseasons/config/SeasonsConfig.java
@@ -8,6 +8,8 @@
 package sereneseasons.config;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 import sereneseasons.api.config.SeasonsOption;
 import sereneseasons.core.SereneSeasons;
@@ -28,6 +30,7 @@ public class SeasonsConfig extends ConfigHandler
     public boolean changeBirchColour;
     
     public String[] whitelistedDimensions;
+    public Map<Integer, Integer> lockedDimensions;
 
     public SeasonsConfig(File configFile)
     {
@@ -53,6 +56,12 @@ public class SeasonsConfig extends ConfigHandler
             changeBirchColour = config.getBoolean("Change Birch Colour Seasonally", AESTHETIC_SETTINGS, true, "Change the birch colour based on the current season");
         
             whitelistedDimensions = config.getStringList("Whitelisted Dimensions", DIMENSION_SETTINGS, new String[] { "0" }, "Seasons will only apply to dimensons listed here");
+            lockedDimensions = new HashMap<>();
+            for (String str : config.getStringList("Locked Dimensions", DIMENSION_SETTINGS, new String[] {""}, "Lock specifics dimensions at a given time of the season cycle. The dimension must be whitelisted as well. Format: dimensionID:time. time must be between 0 and day_duration * sub_season_duration * 12. If not, it will be considered being 0."))
+            {
+            	lockedDimensions.put(Integer.valueOf(str.split(":")[0]), Integer.valueOf(str.split(":")[1]));
+            }
+            
         }
         catch (Exception e)
         {
@@ -76,4 +85,12 @@ public class SeasonsConfig extends ConfigHandler
     	
     	return false;
     }
+    
+   public static boolean isDimensionLocked(int dimension) {
+	   return ModConfig.seasons.lockedDimensions.containsKey(dimension);
+   }
+   
+   public static int getDimensionTimelock(int dimension) {
+	   return ModConfig.seasons.lockedDimensions.get(dimension);
+   }
 }

--- a/src/main/java/sereneseasons/handler/season/SeasonHandler.java
+++ b/src/main/java/sereneseasons/handler/season/SeasonHandler.java
@@ -150,7 +150,9 @@ public class SeasonHandler implements SeasonHelper.ISeasonDataProvider
         if (!world.isRemote)
         {
             SeasonSavedData savedData = getSeasonSavedData(world);
-            PacketHandler.instance.sendToAll(new MessageSyncSeasonCycle(world.provider.getDimension(), savedData.seasonCycleTicks));
+            int dimension = world.provider.getDimension();
+            int seasonCycleTick = SeasonsConfig.isDimensionLocked(dimension) ? SeasonsConfig.getDimensionTimelock(dimension) : savedData.seasonCycleTicks;
+        	PacketHandler.instance.sendToAll(new MessageSyncSeasonCycle(world.provider.getDimension(), seasonCycleTick));
         }
     }
     

--- a/src/main/java/sereneseasons/handler/season/SeasonHandler.java
+++ b/src/main/java/sereneseasons/handler/season/SeasonHandler.java
@@ -91,7 +91,14 @@ public class SeasonHandler implements SeasonHelper.ISeasonDataProvider
 
         if (event.phase == TickEvent.Phase.END && SeasonsConfig.isDimensionWhitelisted(dimension))
         {
-            clientSeasonCycleTicks.compute(dimension, (k, v) -> v == null ? 0 : v + 1);
+        	if (SeasonsConfig.isDimensionLocked(dimension))
+        	{
+        		clientSeasonCycleTicks.put(dimension, SeasonsConfig.getDimensionTimelock(dimension));
+        	}
+        	else
+        	{
+        		clientSeasonCycleTicks.compute(dimension, (k, v) -> v == null ? 0 : v + 1);
+        	}
         	
             //Keep ticking as we're synchronized with the server only every second
             if (clientSeasonCycleTicks.get(dimension) > SeasonTime.ZERO.getCycleDuration())
@@ -182,7 +189,14 @@ public class SeasonHandler implements SeasonHelper.ISeasonDataProvider
     public ISeasonState getServerSeasonState(World world)
     {
         SeasonSavedData savedData = getSeasonSavedData(world);
-        return new SeasonTime(savedData.seasonCycleTicks);
+        if (SeasonsConfig.isDimensionLocked(world.provider.getDimension()))
+        {
+        	return new SeasonTime(SeasonsConfig.getDimensionTimelock(world.provider.getDimension()));
+        }
+        else
+        {
+        	return new SeasonTime(savedData.seasonCycleTicks);
+        }
     }
     
     public ISeasonState getClientSeasonState()


### PR DESCRIPTION
Adds an option to lock certain dimensions to a certain time of the season cycle.

Bugs:
+ major lag spike every second or so. Might be due to the coloration changing abruptly on the client, I could briefly saw all grass reverting to the "normal" season color (spring) whil the overworld was locked into late winter.
+ If server configuration is different than client configuration, client-side is unaware that season is locked