### PR TITLE
[1.7.10] Backport Bugfixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 minecraft_version=1.7.10
 forge_version=10.13.4.1481-1.7.10
-mod_version=1.2.18
+mod_version=1.2.19

--- a/src/main/java/sereneseasons/asm/transformer/ColorTransformer.java
+++ b/src/main/java/sereneseasons/asm/transformer/ColorTransformer.java
@@ -14,7 +14,6 @@ import net.minecraft.launchwrapper.IClassTransformer;
 
 public class ColorTransformer implements IClassTransformer
 {
-
     @Override
     public byte[] transform(String name, String transformedName, byte[] bytes)
     {
@@ -43,7 +42,10 @@ public class ColorTransformer implements IClassTransformer
                     if (instruction.getOpcode() == Opcodes.INVOKESPECIAL)
                     {
                         MethodInsnNode superCall = (MethodInsnNode) instruction;
-                        superCall.name = "colorMultiplierOld";
+                        if (superCall.name.equals("colorMultiplier") || superCall.name.equals("func_149720_d") || (superCall.name.equals("d") && superCall.desc.equals("(Lahl;III)I")))
+                        {
+                            superCall.name = "colorMultiplierOld";
+                        }
                     }
                 }
             }

--- a/src/main/java/sereneseasons/block/BlockGreenhouseGlass.java
+++ b/src/main/java/sereneseasons/block/BlockGreenhouseGlass.java
@@ -7,12 +7,10 @@
  ******************************************************************************/
 package sereneseasons.block;
 
-import java.util.Random;
-
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockBreakable;
+import net.minecraft.block.BlockGlass;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.item.ItemBlock;
@@ -21,17 +19,20 @@ import sereneseasons.api.ISSBlock;
 import sereneseasons.core.SereneSeasons;
 import sereneseasons.item.ItemSSBlock;
 
-public class BlockGreenhouseGlass extends BlockBreakable implements ISSBlock
+public class BlockGreenhouseGlass extends BlockGlass implements ISSBlock
 {
     // implement ISSBlock
     @Override
-    public Class<? extends ItemBlock> getItemClass() { return ItemSSBlock.class; }
+    public Class<? extends ItemBlock> getItemClass()
+    {
+        return ItemSSBlock.class;
+    }
 
     IIcon icon;
 
     public BlockGreenhouseGlass()
     {
-        super("", Material.glass, false);
+        super(Material.glass, false);
         this.setHardness(0.3F);
         this.setHarvestLevel("pickaxe", 0);
         this.setStepSound(Block.soundTypeGlass);
@@ -48,25 +49,9 @@ public class BlockGreenhouseGlass extends BlockBreakable implements ISSBlock
         return this.icon;
     }
 
-    /**
-     * Returns the quantity of items to drop on block destruction.
-     */
-    @Override
-    public int quantityDropped(Random random)
+    @SideOnly(Side.CLIENT)
+    public int getRenderBlockPass()
     {
-        return 0;
+        return 1;
     }
-
-    @Override
-    public boolean isOpaqueCube()
-    {
-        return false;
-    }
-
-    @Override
-    protected boolean canSilkHarvest()
-    {
-        return true;
-    }
-
 }

--- a/src/main/java/sereneseasons/command/SSCommand.java
+++ b/src/main/java/sereneseasons/command/SSCommand.java
@@ -9,7 +9,9 @@ import net.minecraft.command.CommandException;
 import net.minecraft.command.ICommandSender;
 import net.minecraft.command.WrongUsageException;
 import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
+import net.minecraft.util.EnumChatFormatting;
 import sereneseasons.api.season.Season;
 import sereneseasons.handler.season.SeasonHandler;
 import sereneseasons.season.SeasonSavedData;
@@ -41,6 +43,12 @@ public class SSCommand extends CommandBase
         return 2;
     }
 
+    String[] getSeasons()
+    {
+        return new String[]
+        { "early_spring", "mid_spring", "late_spring", "early_summer", "mid_summer", "late_summer", "early_autum", "mid_autumn", "late_autumn", "early_winter", "mid_winter", "late_winter" };
+    }
+
     @Override
     public void processCommand(ICommandSender sender, String[] args) throws CommandException
     {
@@ -50,6 +58,12 @@ public class SSCommand extends CommandBase
         }
         else if ("setseason".equals(args[0]))
         {
+            if (args.length < 2)
+            {
+                sender.addChatMessage(new ChatComponentText("Available seasons:"));
+                sender.addChatMessage(new ChatComponentText(String.join(" ", getSeasons())));
+                return;
+            }
             setSeason(sender, args);
         }
     }
@@ -88,6 +102,11 @@ public class SSCommand extends CommandBase
         if (args.length == 1)
         {
             return getListOfStringsMatchingLastWord(args, "setseason");
+        }
+
+        if (args.length == 2)
+        {
+            return getListOfStringsMatchingLastWord(args, getSeasons());
         }
 
         return null;

--- a/src/main/java/sereneseasons/init/ModFertility.java
+++ b/src/main/java/sereneseasons/init/ModFertility.java
@@ -207,7 +207,16 @@ public class ModFertility
         // Set up tooltips if enabled and on client side
         if (FertilityConfig.general_category.crop_tooltips && FertilityConfig.general_category.seasonal_crops)
         {
-            String name = GameRegistry.findUniqueIdentifierFor(event.itemStack.getItem()).toString();
+            String name;
+            try
+            {
+                // Some mods register items with null as name. This crashes inside findUniqueIdentifierFor, so we need to catch that...
+                name = GameRegistry.findUniqueIdentifierFor(event.itemStack.getItem()).toString();
+            }
+            catch (Exception ex)
+            {
+                return;
+            }
             if (seedSeasons.containsKey(name))
             {
                 int mask = seedSeasons.get(name);

--- a/src/main/java/sereneseasons/item/ItemSeasonClock.java
+++ b/src/main/java/sereneseasons/item/ItemSeasonClock.java
@@ -56,6 +56,8 @@ public class ItemSeasonClock extends Item
         {
             float frame = apply(stack, (World) worldClient, (EntityLivingBase) entityClientPlayerMP);
             int index = (int) Math.round(frame * 64);
+            if (index >= 64)
+                index = 0;
             return this.icons[index];
         }
         return this.itemIcon;

--- a/src/main/java/sereneseasons/mixins/BiomeMixin.java
+++ b/src/main/java/sereneseasons/mixins/BiomeMixin.java
@@ -4,6 +4,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.BiomeGenBase;
@@ -57,6 +59,7 @@ public abstract class BiomeMixin implements IBiomeMixin
      * @reason Redirect to our coloring handlers.
      */
     @Overwrite
+    @SideOnly(Side.CLIENT)
     public boolean canSpawnLightningBolt()
     {
         World world = Minecraft.getMinecraft().theWorld;
@@ -72,6 +75,7 @@ public abstract class BiomeMixin implements IBiomeMixin
      * @reason Redirect to our coloring handlers.
      */
     @Overwrite
+    @SideOnly(Side.CLIENT)
     public boolean getEnableSnow()
     {
         World world = Minecraft.getMinecraft().theWorld;
@@ -87,6 +91,7 @@ public abstract class BiomeMixin implements IBiomeMixin
      * @reason Redirect to our coloring handlers.
      */
     @Overwrite
+    @SideOnly(Side.CLIENT)
     public float getFloatTemperature(int x, int y, int z)
     {
         World world = Minecraft.getMinecraft().theWorld;

--- a/src/main/java/sereneseasons/mixins/BlockMixin.java
+++ b/src/main/java/sereneseasons/mixins/BlockMixin.java
@@ -3,6 +3,8 @@ package sereneseasons.mixins;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockBush;
 import net.minecraft.block.BlockGrass;
@@ -56,6 +58,7 @@ public abstract class BlockMixin
      * @reason Redirect to our coloring handlers.
      */
     @Overwrite
+    @SideOnly(Side.CLIENT)
     public int colorMultiplier(IBlockAccess blockAccess, int x, int y, int z)
     {
         Block block = (Block) (Object) this;

--- a/src/main/java/sereneseasons/season/SeasonASMHelper.java
+++ b/src/main/java/sereneseasons/season/SeasonASMHelper.java
@@ -64,7 +64,7 @@ public class SeasonASMHelper
         }
         else if (checkLight)
         {
-            if (y >= 0 && y < 256 && world.getSkyBlockTypeBrightness(EnumSkyBlock.Block, x, y, z) < 10)
+            if (y >= 0 && y < 256 && world.getSavedLightValue(EnumSkyBlock.Block, x, y, z) < 10)
             {
                 Block block = world.getBlock(x, y, z);
 
@@ -111,7 +111,7 @@ public class SeasonASMHelper
         }
         else
         {
-            if (y >= 0 && y < 256 && world.getSkyBlockTypeBrightness(EnumSkyBlock.Block, x, y, z) < 10)
+            if (y >= 0 && y < 256 && world.getSavedLightValue(EnumSkyBlock.Block, x, y, z) < 10)
             {
                 Block block = world.getBlock(x, y, z);
                 int meta = world.getBlockMetadata(x, y, z);

--- a/src/main/java/sereneseasons/util/SeasonColourUtil.java
+++ b/src/main/java/sereneseasons/util/SeasonColourUtil.java
@@ -10,6 +10,8 @@ package sereneseasons.util;
 
 import org.lwjgl.util.Color;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.biome.BiomeGenBase;
 import sereneseasons.api.season.ISeasonColorProvider;
@@ -60,6 +62,7 @@ public class SeasonColourUtil
         return getIntFromColour(newColour);
     }
     
+    @SideOnly(Side.CLIENT)
     public static int applySeasonalGrassColouring(ISeasonColorProvider colorProvider, BiomeGenBase biome, int originalColour)
     {
         if (!BiomeConfig.enablesSeasonalEffects(biome) || !SeasonsConfig.isDimensionWhitelisted(Minecraft.getMinecraft().thePlayer.dimension))
@@ -76,6 +79,7 @@ public class SeasonColourUtil
         return saturationMultiplier != -1 ? saturateColour(newColour, saturationMultiplier) : newColour;
     }
     
+    @SideOnly(Side.CLIENT)
     public static int applySeasonalFoliageColouring(ISeasonColorProvider colorProvider, BiomeGenBase biome, int originalColour)
     {
         if (!BiomeConfig.enablesSeasonalEffects(biome) || !SeasonsConfig.isDimensionWhitelisted(Minecraft.getMinecraft().thePlayer.dimension))


### PR DESCRIPTION
Fixes the following issues:
- Don't crash when used on the server side
- Don't crash for mods registering an item with a null-name
- Prevent out of bounds access in season clock
- Properly do asm transforming, fixes issues with ThaumicInfusions
- Fix glass rendering
- Improve creative commands