### PR TITLE
Add loot tables for 1.14.4 so that season sensors can drop when broken.

### DIFF
--- a/src/main/resources/data/sereneseasons/loot_tables/blocks/season_sensor_autumn.json
+++ b/src/main/resources/data/sereneseasons/loot_tables/blocks/season_sensor_autumn.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "sereneseasons:season_sensor_autumn"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/sereneseasons/loot_tables/blocks/season_sensor_spring.json
+++ b/src/main/resources/data/sereneseasons/loot_tables/blocks/season_sensor_spring.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "sereneseasons:season_sensor_spring"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/sereneseasons/loot_tables/blocks/season_sensor_summer.json
+++ b/src/main/resources/data/sereneseasons/loot_tables/blocks/season_sensor_summer.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "sereneseasons:season_sensor_summer"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/sereneseasons/loot_tables/blocks/season_sensor_winter.json
+++ b/src/main/resources/data/sereneseasons/loot_tables/blocks/season_sensor_winter.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "sereneseasons:season_sensor_winter"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Small patch to add loot tables to 1.14.4 so that season sensors can drop when broken.