### PR TITLE
Master

### DIFF
--- a/src/main/java/sereneseasons/command/SSCommand.java
+++ b/src/main/java/sereneseasons/command/SSCommand.java
@@ -12,10 +12,12 @@ import net.minecraft.util.text.TextComponentTranslation;
 import sereneseasons.api.config.SeasonsOption;
 import sereneseasons.api.config.SyncedConfig;
 import sereneseasons.api.season.Season;
+import sereneseasons.api.season.Season.SubSeason;
 import sereneseasons.handler.season.SeasonHandler;
 import sereneseasons.season.SeasonSavedData;
 import sereneseasons.season.SeasonTime;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class SSCommand extends CommandBase
@@ -91,6 +93,10 @@ public class SSCommand extends CommandBase
         if (args.length == 1)
         {
             return getListOfStringsMatchingLastWord(args, "setseason");
+        }
+        else if (args.length == 2)
+        {
+            return getListOfStringsMatchingLastWord(args, Arrays.stream(SubSeason.values()).map(e -> e.toString().toLowerCase()).toArray(String[]::new));
         }
 
         return null;

--- a/src/main/java/sereneseasons/command/SSCommand.java
+++ b/src/main/java/sereneseasons/command/SSCommand.java
@@ -99,6 +99,6 @@ public class SSCommand extends CommandBase
             return getListOfStringsMatchingLastWord(args, Arrays.stream(SubSeason.values()).map(e -> e.toString().toLowerCase()).toArray(String[]::new));
         }
 
-        return null;
+        return super.getTabCompletions(server, sender, args, pos);
     }
 }


### PR DESCRIPTION
This fix allows for command line completion of the subseason names in the setseason command.  As an added benefit it also prevents the exception from being thrown when tabbing by not returning null.