### PR TITLE
Polish translations for wet and dry season labels and `doSeasonCycle` gamerule.

### DIFF
--- a/common/src/main/resources/assets/sereneseasons/lang/pl_pl.json
+++ b/common/src/main/resources/assets/sereneseasons/lang/pl_pl.json
@@ -5,16 +5,18 @@
   "commands.sereneseasons.setseason.fail": "Nieprawidłowa pora roku: %s",
   "commands.sereneseasons.setseason.disabled": "Pory roku są obecnie wyłączone!",
 
+  "gamerule.doSeasonCycle": "Postępujące pory roku",
   "itemGroup.tabSereneSeasons": "Serene Seasons",
 
   "block.sereneseasons.season_sensor": "Czujnik pory roku",
-  
+
   "item.sereneseasons.ss_icon": "SS Icon",
   "item.sereneseasons.calendar": "Kalendarz",
 
   "desc.sereneseasons.fertile_seasons": "Urodzajne pory:",
   "desc.sereneseasons.year_round": "Całorocznie",
   "desc.sereneseasons.day_counter": "Dzień %s/%s",
+  "desc.sereneseasons.tropical_day_counter": " (%s/%s)",
   "desc.sereneseasons.spring": "Wiosna",
   "desc.sereneseasons.early_spring": "Wczesna wiosna",
   "desc.sereneseasons.mid_spring": "Środek wiosny",
@@ -30,5 +32,12 @@
   "desc.sereneseasons.winter": "Zima",
   "desc.sereneseasons.early_winter": "Wczesna zima",
   "desc.sereneseasons.mid_winter": "Środek zimy",
-  "desc.sereneseasons.late_winter": "Późna zima"
+  "desc.sereneseasons.late_winter": "Późna zima",
+
+  "desc.sereneseasons.early_wet": "Wczesna pora deszczowa",
+  "desc.sereneseasons.mid_wet": "Pora deszczowa",
+  "desc.sereneseasons.late_wet": "Późna pora deszczowa",
+  "desc.sereneseasons.early_dry": "Wczesna pora sucha",
+  "desc.sereneseasons.mid_dry": "Pora sucha",
+  "desc.sereneseasons.late_dry": "Późna pora sucha"
 }


### PR DESCRIPTION
Hello, I noticed some missing Polish translations and decided to add them. I’ve added translations for the following:
- `gamerule.doSeasonCycle`
- `desc.sereneseasons.early_wet`
- `desc.sereneseasons.mid_wet`
- `desc.sereneseasons.late_wet`
- `desc.sereneseasons.early_dry`
- `desc.sereneseasons.mid_dry`
- `desc.sereneseasons.late_dry`

I tested the resulting translation file as a resource pack.

Thank you for creating this mod.