### PR TITLE
Re-added logic to account for time skips

### DIFF
--- a/common/src/main/java/sereneseasons/season/SeasonHandler.java
+++ b/common/src/main/java/sereneseasons/season/SeasonHandler.java
@@ -62,6 +62,11 @@ public class SeasonHandler implements SeasonHelper.ISeasonDataProvider
         if (difference == 0)
             return;
 
+        if (difference < 0)
+        {
+            difference += 24000L;
+        }
+
         SeasonSavedData savedData = getSeasonSavedData(level);
         savedData.seasonCycleTicks = Mth.positiveModulo(savedData.seasonCycleTicks + (int)difference, SeasonTime.ZERO.getCycleDuration());
 


### PR DESCRIPTION
It looks like the TimeSkipHandler didn't fully make it over in the 1.20.4 refactor, and using the "/time day" command sets the season back in time. This just re-adds the logic to check for negative time difference, and adds a day instead.