### PR TITLE
Fix seasonal foliage colors in Distant Horizons

### DIFF
--- a/common/src/main/java/sereneseasons/init/ModClient.java
+++ b/common/src/main/java/sereneseasons/init/ModClient.java
@@ -22,8 +22,10 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.FoliageColor;
+import net.minecraft.world.level.GrassColor;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import sereneseasons.api.SSItems;
@@ -42,6 +44,26 @@ import java.util.Locale;
 
 public class ModClient
 {
+    private static final Block[] SEASONAL_FOLIAGE_BLOCKS = new Block[] {
+            Blocks.OAK_LEAVES,
+            Blocks.JUNGLE_LEAVES,
+            Blocks.ACACIA_LEAVES,
+            Blocks.DARK_OAK_LEAVES,
+            Blocks.MANGROVE_LEAVES,
+            Blocks.AZALEA_LEAVES,
+            Blocks.FLOWERING_AZALEA_LEAVES,
+            Blocks.VINE
+    };
+
+    private static final Block[] SEASONAL_GRASS_BLOCKS = new Block[] {
+            Blocks.GRASS_BLOCK,
+            Blocks.SHORT_GRASS,
+            Blocks.TALL_GRASS,
+            Blocks.FERN,
+            Blocks.LARGE_FERN,
+            Blocks.SUGAR_CANE
+    };
+
     public static void setup()
     {
         SeasonColorHandlers.setup();
@@ -188,5 +210,44 @@ public class ModClient
 
             return birchColor;
         }, Blocks.BIRCH_LEAVES);
+
+        event.register(ModClient::resolveSeasonalFoliageColor, SEASONAL_FOLIAGE_BLOCKS);
+        event.register(ModClient::resolveSeasonalGrassColor, SEASONAL_GRASS_BLOCKS);
+    }
+
+    private static int resolveSeasonalFoliageColor(BlockState state, @Nullable BlockAndTintGetter blockGetter, @Nullable BlockPos pos, int tintIndex)
+    {
+        Level level = resolveLevel(blockGetter);
+        if (pos == null || level == null)
+        {
+            return -1;
+        }
+
+        Holder<Biome> biome = level.getBiome(pos);
+        return SeasonColorHandlers.getSeasonalColor(level, biome, pos.getX(), pos.getZ(), SeasonColorHandlers.ResolverType.FOLIAGE);
+    }
+
+    private static int resolveSeasonalGrassColor(BlockState state, @Nullable BlockAndTintGetter blockGetter, @Nullable BlockPos pos, int tintIndex)
+    {
+        Level level = resolveLevel(blockGetter);
+        if (pos == null || level == null)
+        {
+            return -1;
+        }
+
+        Holder<Biome> biome = level.getBiome(pos);
+        return SeasonColorHandlers.getSeasonalColor(level, biome, pos.getX(), pos.getZ(), SeasonColorHandlers.ResolverType.GRASS);
+    }
+
+    @Nullable
+    private static Level resolveLevel(@Nullable BlockAndTintGetter blockGetter)
+    {
+        if (blockGetter instanceof Level level)
+        {
+            return level;
+        }
+
+        Minecraft minecraft = Minecraft.getInstance();
+        return minecraft.level;
     }
 }

--- a/common/src/main/java/sereneseasons/season/SeasonColorHandlers.java
+++ b/common/src/main/java/sereneseasons/season/SeasonColorHandlers.java
@@ -70,24 +70,63 @@ public class SeasonColorHandlers
 
         if (biomeHolder != null)
         {
-            ISeasonState calendar = SeasonHelper.getSeasonState(level);
-            ISeasonColorProvider colorProvider = biomeHolder.is(ModTags.Biomes.TROPICAL_BIOMES) ? calendar.getTropicalSeason() : calendar.getSubSeason();
-
-            int seasonalColor = switch (type) {
-                case GRASS -> SeasonColorUtil.applySeasonalGrassColouring(colorProvider, biomeHolder, originalColor);
-                case FOLIAGE -> SeasonColorUtil.applySeasonalFoliageColouring(colorProvider, biomeHolder, originalColor);
-            };
-
-            int currentColor = seasonalColor;
-            for (ColorOverride override : resolverOverrides.get(type))
-            {
-                currentColor = override.apply(originalColor, seasonalColor, currentColor, biomeHolder, x, z);
-            }
-
-            return currentColor;
+            return getSeasonalColor(level, biomeHolder, x, z, type, originalColor);
         }
 
         return originalColor;
+    }
+
+    public static int getSeasonalColor(@Nullable Level level, Holder<Biome> biomeHolder, double x, double z, ResolverType type)
+    {
+        int originalColor = originalColorFor(biomeHolder, x, z, type);
+        return getSeasonalColor(level, biomeHolder, x, z, type, originalColor);
+    }
+
+    public static int getSeasonalColor(@Nullable Level level, Holder<Biome> biomeHolder, double x, double z, ResolverType type, int originalColor)
+    {
+        if (level == null || biomeHolder == null)
+        {
+            return originalColor;
+        }
+
+        if (biomeHolder.is(ModTags.Biomes.BLACKLISTED_BIOMES) || !ModConfig.seasons.isDimensionWhitelisted(level.dimension()))
+        {
+            return originalColor;
+        }
+
+        ISeasonState calendar = SeasonHelper.getSeasonState(level);
+        ISeasonColorProvider colorProvider = biomeHolder.is(ModTags.Biomes.TROPICAL_BIOMES) ? calendar.getTropicalSeason() : calendar.getSubSeason();
+
+        int seasonalColor = switch (type) {
+            case GRASS -> SeasonColorUtil.applySeasonalGrassColouring(colorProvider, biomeHolder, originalColor);
+            case FOLIAGE -> SeasonColorUtil.applySeasonalFoliageColouring(colorProvider, biomeHolder, originalColor);
+        };
+
+        int currentColor = seasonalColor;
+        for (ColorOverride override : resolverOverrides.get(type))
+        {
+            currentColor = override.apply(originalColor, seasonalColor, currentColor, biomeHolder, x, z);
+        }
+
+        return currentColor;
+    }
+
+    private static int originalColorFor(Holder<Biome> biomeHolder, double x, double z, ResolverType type)
+    {
+        ColorResolver resolver = switch (type) {
+            case GRASS -> originalGrassColorResolver;
+            case FOLIAGE -> originalFoliageColorResolver;
+        };
+
+        if (resolver != null)
+        {
+            return resolver.getColor(biomeHolder.value(), x, z);
+        }
+
+        return switch (type) {
+            case GRASS -> biomeHolder.value().getGrassColor(x, z);
+            case FOLIAGE -> biomeHolder.value().getFoliageColor();
+        };
     }
 
     public interface ColorOverride


### PR DESCRIPTION
- Problem: Distant Horizons only queried per-block color handlers. Serene Seasons only registered one for birch leaves, relying on biome color resolvers for everything else. DH therefore rendered oak leaves and grass with vanilla colors outside the main render distance.

- Root Cause: Missing block color registrations for seasonal-tinted foliage/grass, while birch had a dedicated handler.

- Fix: Added reusable SeasonColorHandlers.getSeasonalColor APIs so other callers can obtain seasonal colors without duplicating resolver logic.
Registered block color callbacks for all foliage/grass blocks, delegating to SeasonColorHandlers and falling back gracefully when context is absent.

- Result: Distant Horizons LODs now receive the same seasonal tint data as birch leaves, keeping grass and other leaves visually consistent at any distance.