### PR TITLE
[1.21.1] Add biome.hasPrecipitation compat

### DIFF
--- a/common/src/main/java/sereneseasons/mixin/client/MixinBiomeClient.java
+++ b/common/src/main/java/sereneseasons/mixin/client/MixinBiomeClient.java
@@ -6,6 +6,8 @@ package sereneseasons.mixin.client;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
 import org.spongepowered.asm.mixin.Mixin;
@@ -17,6 +19,21 @@ import sereneseasons.season.SeasonHooks;
 @Mixin(Biome.class)
 public class MixinBiomeClient
 {
+    @Inject(method="hasPrecipitation", at=@At("HEAD"), cancellable = true)
+    public void onHasPrecipitation(CallbackInfoReturnable<Boolean> cir)
+    {
+        Level level = Minecraft.getInstance().level;
+
+        if (level == null)
+            return;
+
+        Holder<Biome> holder = level.registryAccess()
+                .registryOrThrow(Registries.BIOME)
+                .wrapAsHolder((Biome) (Object) this);
+
+        cir.setReturnValue(SeasonHooks.hasPrecipitationSeasonal(level, holder));
+    }
+
     @Inject(method="getPrecipitationAt", at=@At("HEAD"), cancellable = true)
     public void onGetPrecipitationAt(BlockPos pos, CallbackInfoReturnable<Biome.Precipitation> cir)
     {


### PR DESCRIPTION
Improves compatibility with other mods that don't have manual support for Serene Seasons.

26.1.2: #602 