### PR TITLE
Port #533 to 1.21.1

### DIFF
--- a/common/src/main/java/sereneseasons/api/season/Season.java
+++ b/common/src/main/java/sereneseasons/api/season/Season.java
@@ -6,6 +6,7 @@ package sereneseasons.api.season;
 
 import com.mojang.serialization.Codec;
 import net.minecraft.util.StringRepresentable;
+import sereneseasons.config.SeasonsConfig.SeasonProperties;
 
 import java.util.Locale;
 
@@ -51,6 +52,14 @@ public enum Season
         SubSeason(Season season, int grassColour, int foliageColour, int birchColor)
         {
             this(season, grassColour, -1, foliageColour, -1, birchColor);
+        }
+
+        public void applyProperties(SeasonProperties properties) {
+            this.grassOverlay = properties.grassColour();
+            this.grassSaturationMultiplier = properties.grassSaturation();
+            this.foliageOverlay = properties.foliageColour();
+            this.foliageSaturationMultiplier = properties.foliageSaturation();
+            this.birchColor = properties.birchColor();
         }
         
         public Season getSeason()

--- a/common/src/main/java/sereneseasons/config/SeasonsConfig.java
+++ b/common/src/main/java/sereneseasons/config/SeasonsConfig.java
@@ -124,13 +124,23 @@ public class SeasonsConfig extends glitchcore.config.Config
                 min_rain_time is the minimum time interval between rain events in ticks. Set to -1 to disable rain.
                 max_rain_time is the maximum time interval between rain events in ticks. Set to -1 to disable rain.
                 min_thunder_time is the minimum time interval between thunder events in ticks. Set to -1 to disable thunder.
-                max_thunder_time is the maximum time interval between thunder events in ticks. Set to -1 to disable thunder.""", SEASON_PROPERTIES_VALIDATOR);
+                max_thunder_time is the maximum time interval between thunder events in ticks. Set to -1 to disable thunder.
+                grass_colour is the color of grass, from 0 to 0xFFFFFF(16777215).
+                grass_saturation is the saturation multiplier of grass color. Set to -1 to disable.
+                foliage_colour is the color of foliage, from 0 to 0xFFFFFF(16777215).
+                foliage_saturation is the saturation multiplier of foliage color. Set to -1 to disable.
+                birch_color is the color of birch foliage, from 0 to 0xFFFFFF(16777215). It will use the same saturation multiplier of foliage_colour""", SEASON_PROPERTIES_VALIDATOR);
 
         seasonPropertiesMapper = Suppliers.memoize(() -> {
             var map = new HashMap<>(DEFAULT_SEASON_PROPERTIES);
             seasonProperties.stream().map(SeasonProperties::decode).forEach(o -> o.ifPresent(v -> map.put(v.subSeason(), v)));
             return map;
         });
+
+        for (var subSeason : Season.SubSeason.VALUES) {
+            var properties = getSeasonProperties(subSeason);
+            subSeason.applyProperties(properties);
+        };
     }
 
     public boolean isDimensionWhitelisted(ResourceKey<Level> dimension)
@@ -152,8 +162,23 @@ public class SeasonsConfig extends glitchcore.config.Config
         return seasonPropertiesMapper.get().get(season);
     }
 
-    public record SeasonProperties(Season.SubSeason subSeason, float meltChance, int meltRolls, float biomeTempAdjustment, int minRainTime, int maxRainTime, int minThunderTime, int maxThunderTime)
-    {
+    public record SeasonProperties(
+        // season
+        Season.SubSeason subSeason,
+        // server side properties
+        float meltChance, int meltRolls, float biomeTempAdjustment, int minRainTime, int maxRainTime, int minThunderTime, int maxThunderTime,
+        // client side properties
+        int grassColour, float grassSaturation, int foliageColour, float foliageSaturation, int birchColor
+    ) {
+        public SeasonProperties(
+            // season
+            Season.SubSeason subSeason,
+            // server side properties
+            float meltChance, int meltRolls, float biomeTempAdjustment, int minRainTime, int maxRainTime, int minThunderTime, int maxThunderTime
+        ) {
+            this(subSeason, meltChance, meltRolls, biomeTempAdjustment, minRainTime, maxRainTime, minThunderTime, maxThunderTime, subSeason.getGrassOverlay(), subSeason.getGrassSaturationMultiplier(), subSeason.getFoliageOverlay(), subSeason.getFoliageSaturationMultiplier(), subSeason.getBirchColor());
+        }
+
         public Config encode()
         {
             Config config = Config.of(LinkedHashMap::new, InMemoryFormat.withUniversalSupport());
@@ -165,6 +190,11 @@ public class SeasonsConfig extends glitchcore.config.Config
             config.add("max_rain_time", this.maxRainTime);
             config.add("min_thunder_time", this.minThunderTime);
             config.add("max_thunder_time", this.maxThunderTime);
+            config.add("grass_colour", this.grassColour);
+            config.add("grass_saturation", this.grassSaturation);
+            config.add("foliage_colour", this.foliageColour);
+            config.add("foliage_saturation", this.foliageSaturation);
+            config.add("birch_color", this.birchColor);
             return config;
         }
 
@@ -180,14 +210,26 @@ public class SeasonsConfig extends glitchcore.config.Config
                 int maxRainTime = config.getInt("max_rain_time");
                 int minThunderTime = config.getInt("min_thunder_time");
                 int maxThunderTime = config.getInt("max_thunder_time");
+                int grassColour = config.getInt("grass_colour");
+                float grassSaturation = config.<Number>get("grass_saturation").floatValue();
+                int foliageColour = config.getInt("foliage_colour");
+                float foliageSaturation = config.<Number>get("foliage_saturation").floatValue();
+                int birchColor = config.getInt("birch_color");
 
                 Preconditions.checkArgument(meltChance >= 0.0F && meltChance <= 100.0F);
                 Preconditions.checkArgument(rolls >= 0);
                 Preconditions.checkArgument(biomeTempAdjustment >= -10.0 && biomeTempAdjustment <= 10.0);
                 Preconditions.checkArgument(minRainTime <= maxRainTime);
                 Preconditions.checkArgument(minThunderTime <= maxThunderTime);
+                Preconditions.checkArgument(grassColour >= 0 && grassColour <= 0xFFFFFF);
+                Preconditions.checkArgument(foliageColour >= 0 && foliageColour <= 0xFFFFFF);
+                Preconditions.checkArgument(birchColor >= 0 && birchColor <= 0xFFFFFF);
 
-                return Optional.of(new SeasonProperties(subSeason, meltChance, rolls, biomeTempAdjustment, minRainTime, maxRainTime, minThunderTime, maxThunderTime));
+                return Optional.of(new SeasonProperties(
+                    subSeason,
+                    meltChance, rolls, biomeTempAdjustment, minRainTime, maxRainTime, minThunderTime, maxThunderTime,
+                    grassColour, grassSaturation, foliageColour, foliageSaturation, birchColor
+                ));
             }
             catch (Exception e)
             {

--- a/common/src/main/java/sereneseasons/config/SeasonsConfig.java
+++ b/common/src/main/java/sereneseasons/config/SeasonsConfig.java
@@ -19,6 +19,7 @@ import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.world.level.Level;
 import sereneseasons.api.season.Season;
 import sereneseasons.core.SereneSeasons;
+import sereneseasons.util.HexColor;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -125,11 +126,11 @@ public class SeasonsConfig extends glitchcore.config.Config
                 max_rain_time is the maximum time interval between rain events in ticks. Set to -1 to disable rain.
                 min_thunder_time is the minimum time interval between thunder events in ticks. Set to -1 to disable thunder.
                 max_thunder_time is the maximum time interval between thunder events in ticks. Set to -1 to disable thunder.
-                grass_colour is the color of grass, from 0 to 0xFFFFFF(16777215).
+                grass_colour is the color of grass in RGB, from 0x000000 to 0xFFFFFF.
                 grass_saturation is the saturation multiplier of grass color. Set to -1 to disable.
-                foliage_colour is the color of foliage, from 0 to 0xFFFFFF(16777215).
+                foliage_colour is the color of foliage in RGB, from 0x000000 to 0xFFFFFF.
                 foliage_saturation is the saturation multiplier of foliage color. Set to -1 to disable.
-                birch_color is the color of birch foliage, from 0 to 0xFFFFFF(16777215). It will use the same saturation multiplier of foliage_colour""", SEASON_PROPERTIES_VALIDATOR);
+                birch_color is the color of birch foliage in RGB, from 0x000000 to 0xFFFFFF. It will use the same saturation multiplier of foliage_colour""", SEASON_PROPERTIES_VALIDATOR);
 
         seasonPropertiesMapper = Suppliers.memoize(() -> {
             var map = new HashMap<>(DEFAULT_SEASON_PROPERTIES);
@@ -140,7 +141,31 @@ public class SeasonsConfig extends glitchcore.config.Config
         for (var subSeason : Season.SubSeason.VALUES) {
             var properties = getSeasonProperties(subSeason);
             subSeason.applyProperties(properties);
-        };
+        }
+    }
+
+    /**
+     * The {@link com.electronwill.nightconfig.toml.TomlParser} sees {@code 0xFF} as an integer, not a {@link HexColor}.
+     * This converts the parse result into {@link HexColor} (where needed).
+     */
+    @Override
+    public void parse(String toml) {
+        super.parse(toml);
+
+        List<Config> seasonConfigs = get("season_properties");
+
+        if (seasonConfigs == null)
+            return;
+
+        for (Config seasonConfig : seasonConfigs) {
+            convertToHexColor(seasonConfig, "grass_colour");
+            convertToHexColor(seasonConfig, "foliage_colour");
+            convertToHexColor(seasonConfig, "birch_color");
+        }
+    }
+
+    private static void convertToHexColor(@Nonnull Config config, String key) {
+        config.set(key, new HexColor(config.getInt(key)));
     }
 
     public boolean isDimensionWhitelisted(ResourceKey<Level> dimension)
@@ -190,11 +215,11 @@ public class SeasonsConfig extends glitchcore.config.Config
             config.add("max_rain_time", this.maxRainTime);
             config.add("min_thunder_time", this.minThunderTime);
             config.add("max_thunder_time", this.maxThunderTime);
-            config.add("grass_colour", this.grassColour);
+            config.add("grass_colour", new HexColor(this.grassColour));
             config.add("grass_saturation", this.grassSaturation);
-            config.add("foliage_colour", this.foliageColour);
+            config.add("foliage_colour", new HexColor(this.foliageColour));
             config.add("foliage_saturation", this.foliageSaturation);
-            config.add("birch_color", this.birchColor);
+            config.add("birch_color", new HexColor(this.birchColor));
             return config;
         }
 

--- a/common/src/main/java/sereneseasons/config/SeasonsConfig.java
+++ b/common/src/main/java/sereneseasons/config/SeasonsConfig.java
@@ -165,7 +165,12 @@ public class SeasonsConfig extends glitchcore.config.Config
     }
 
     private static void convertToHexColor(@Nonnull Config config, String key) {
-        config.set(key, new HexColor(config.getInt(key)));
+        Number value = config.get(key);
+
+        if (value == null)
+            return;
+
+        config.set(key, new HexColor(value.intValue()));
     }
 
     public boolean isDimensionWhitelisted(ResourceKey<Level> dimension)

--- a/common/src/main/java/sereneseasons/util/HexColor.java
+++ b/common/src/main/java/sereneseasons/util/HexColor.java
@@ -1,0 +1,49 @@
+package sereneseasons.util;
+
+import java.util.HexFormat;
+
+public final class HexColor extends Number {
+    private static final HexFormat HEX_FORMAT = HexFormat.of().withUpperCase();
+    public final int color;
+
+    public HexColor(int color) {
+        this.color = color;
+    }
+
+    @Override
+    public String toString() {
+        return "0x" + HEX_FORMAT.toHexDigits(color).substring(2);
+    }
+
+    @Override
+    public int intValue() {
+        return color;
+    }
+
+    @Override
+    public long longValue() {
+        return color;
+    }
+
+    @Override
+    public float floatValue() {
+        return color;
+    }
+
+    @Override
+    public double doubleValue() {
+        return color;
+    }
+
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(color);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (!(obj instanceof HexColor other)) return false;
+        return color == other.color;
+    }
+}


### PR DESCRIPTION
Ports #533 to 1.21.1
(Related to #576)

This pr is a bit different than #533, though. It stores colors in the .toml as hex literals. i.e.,
```toml
[[season_properties]]
	grass_saturation = -1.0
	min_rain_time = 12000
	grass_colour = 0x877777
	biome_temp_adjustment = 0.0
	foliage_saturation = -1.0
	birch_color = 0x98A54B
	melt_percent = 25.0
	max_rain_time = 96000
	season = "LATE_SUMMER"
	melt_rolls = 1
	max_thunder_time = 180000
	foliage_colour = 0x9F5F5F
	min_thunder_time = 12000
```
Night config has support for reading hex literals already.