### PR TITLE
Backport the season integration API from 26.x (#609)

### DIFF
--- a/common/src/main/java/sereneseasons/api/season/ISeasonState.java
+++ b/common/src/main/java/sereneseasons/api/season/ISeasonState.java
@@ -44,6 +44,32 @@ public interface ISeasonState
      */
     int getSeasonCycleTicks();
 
+    default float getCycleProgress()
+    {
+        int duration = getSubSeasonDuration();
+        if (duration <= 0)
+            return 0.0F;
+
+        int count = Season.SubSeason.VALUES.length;
+        int index = (getSeasonCycleTicks() / duration) % count;
+        double elapsed = (double)(getSeasonCycleTicks() % duration) / (double)duration;
+        return clampProgress((float)((index + elapsed) / count));
+    }
+
+    default float getSubSeasonProgress()
+    {
+        int duration = getSubSeasonDuration();
+        if (duration <= 0)
+            return 0.0F;
+
+        return clampProgress((float)((double)(getSeasonCycleTicks() % duration) / (double)duration));
+    }
+
+    private static float clampProgress(float progress)
+    {
+        return progress < 1.0F ? progress : Math.nextDown(1.0F);
+    }
+
     /**
      * Get the number of days elapsed.
      *

--- a/common/src/main/java/sereneseasons/api/season/SeasonHelper.java
+++ b/common/src/main/java/sereneseasons/api/season/SeasonHelper.java
@@ -4,6 +4,7 @@
  ******************************************************************************/
 package sereneseasons.api.season;
 
+import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.biome.Biome;
@@ -42,10 +43,60 @@ public class SeasonHelper
         return dataProvider.usesTropicalSeasons(biome);
     }
 
+    public static boolean usesTropicalSeasons(Level level, BlockPos pos)
+    {
+        return dataProvider.usesTropicalSeasons(level.getBiome(pos));
+    }
+
+    public static boolean hasSeasons(Level level)
+    {
+        return dataProvider.hasSeasons(level);
+    }
+
+    public static boolean usesStandardSeasons(Level level, BlockPos pos)
+    {
+        return hasSeasons(level) && !usesTropicalSeasons(level, pos);
+    }
+
+    public static boolean changesGrassColor(Level level)
+    {
+        return dataProvider.changesGrassColor(level);
+    }
+
+    public static boolean changesFoliageColor(Level level)
+    {
+        return dataProvider.changesFoliageColor(level);
+    }
+
+    public static boolean changesBirchColor(Level level)
+    {
+        return dataProvider.changesBirchColor(level);
+    }
+
     public interface ISeasonDataProvider
     {
         ISeasonState getServerSeasonState(Level level);
         ISeasonState getClientSeasonState(Level level);
         boolean usesTropicalSeasons(Holder<Biome> key);
+
+        default boolean hasSeasons(Level level)
+        {
+            return true;
+        }
+
+        default boolean changesGrassColor(Level level)
+        {
+            return true;
+        }
+
+        default boolean changesFoliageColor(Level level)
+        {
+            return true;
+        }
+
+        default boolean changesBirchColor(Level level)
+        {
+            return true;
+        }
     }
 }

--- a/common/src/main/java/sereneseasons/season/SeasonHandler.java
+++ b/common/src/main/java/sereneseasons/season/SeasonHandler.java
@@ -171,4 +171,28 @@ public class SeasonHandler implements SeasonHelper.ISeasonDataProvider
     {
         return biome.is(ModTags.Biomes.TROPICAL_BIOMES);
     }
+
+    @Override
+    public boolean hasSeasons(Level level)
+    {
+        return level != null && ModConfig.seasons.isDimensionWhitelisted(level.dimension());
+    }
+
+    @Override
+    public boolean changesGrassColor(Level level)
+    {
+        return ModConfig.seasons.changeGrassColor && hasSeasons(level);
+    }
+
+    @Override
+    public boolean changesFoliageColor(Level level)
+    {
+        return ModConfig.seasons.changeFoliageColor && hasSeasons(level);
+    }
+
+    @Override
+    public boolean changesBirchColor(Level level)
+    {
+        return ModConfig.seasons.changeBirchColor && hasSeasons(level);
+    }
 }


### PR DESCRIPTION
Brings the 1.21.11 branch's api package to parity with 26.2 for mods that integrate with the season cycle, by applying #609